### PR TITLE
Urls test

### DIFF
--- a/src/Urls.php
+++ b/src/Urls.php
@@ -9,8 +9,8 @@ class Urls {
         $user      = $parsed['user'] ?? null;
         $userinfo  = $pass !== null ? "$user:$pass" : $user;
         $port      = $parsed['port'] ?? 0;
-        $scheme    = $parsed['scheme'] ?? "";
-        $query     = $parsed['query'] ?? "";
+        $scheme    = $parsed['scheme'] ?? null;
+        $query     = $parsed['query'] ?? null;
         $fragment  = $parsed['fragment'] ?? "";
         $authority = (
             ($userinfo !== null ? "$userinfo@" : "") .
@@ -18,7 +18,6 @@ class Urls {
             ($port ? ":$port" : "")
         );
         return (
-            (\strlen($scheme) > 0 ? "$scheme:" : "") .
             (\strlen($authority) > 0 ? "//$authority" : "") .
             ($parsed['path'] ?? "") .
             (\strlen($query) > 0 ? "?$query" : "") .

--- a/src/Urls.php
+++ b/src/Urls.php
@@ -1,27 +1,37 @@
-<?php declare(strict_types=1);
+<?php 
 
 namespace Missing;
+
+use InvalidArgumentException;
 
 class Urls {
 
     public static function unparse_url(array $parsed): string {
-        $pass      = $parsed['pass'] ?? null;
-        $user      = $parsed['user'] ?? null;
+        if(!is_array($parsed)) {
+            throw new InvalidArgumentException("Input must be an array returned by parse_url");
+        };
+
+        $scheme = $parsed['scheme'] ?? null;
+        $host = $parsed['host'] ?? null;
+        $port = $parsed['port'] ?? null;
+        $user = $parsed['user'] ?? null;
+        $pass = $parsed['pass'] ?? null;
+        $path = $parsed['path'] ?? '';
+        $query = $parsed['query'] ?? null;
+        $fragment = $parsed['fragment'] ?? null;
+        
         $userinfo  = $pass !== null ? "$user:$pass" : $user;
-        $port      = $parsed['port'] ?? 0;
-        $scheme    = $parsed['scheme'] ?? null;
-        $query     = $parsed['query'] ?? null;
-        $fragment  = $parsed['fragment'] ?? "";
         $authority = (
             ($userinfo !== null ? "$userinfo@" : "") .
             ($parsed['host'] ?? "") .
             ($port ? ":$port" : "")
         );
         return (
-            (\strlen($authority) > 0 ? "//$authority" : "") .
-            ($parsed['path'] ?? "") .
-            (\strlen($query ?? '') > 0 ? "?$query" : "") .
-            (\strlen($fragment) > 0 ? "#$fragment" : "")
+            ($scheme !== null ? "$scheme://" : "") .
+            ($authority !== null ? "//$authority" : "") .
+            ($path !== null ?? "") .
+            ($query !== null ? "$query" : "") .
+            ($fragment !== null ? "#$fragment" : "")
         );
     }
 

--- a/src/Urls.php
+++ b/src/Urls.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Missing;
+
+class Urls {
+
+    public static function unparse_url(array $parsed): string {
+        $pass      = $parsed['pass'] ?? null;
+        $user      = $parsed['user'] ?? null;
+        $userinfo  = $pass !== null ? "$user:$pass" : $user;
+        $port      = $parsed['port'] ?? 0;
+        $scheme    = $parsed['scheme'] ?? "";
+        $query     = $parsed['query'] ?? "";
+        $fragment  = $parsed['fragment'] ?? "";
+        $authority = (
+            ($userinfo !== null ? "$userinfo@" : "") .
+            ($parsed['host'] ?? "") .
+            ($port ? ":$port" : "")
+        );
+        return (
+            (\strlen($scheme) > 0 ? "$scheme:" : "") .
+            (\strlen($authority) > 0 ? "//$authority" : "") .
+            ($parsed['path'] ?? "") .
+            (\strlen($query) > 0 ? "?$query" : "") .
+            (\strlen($fragment) > 0 ? "#$fragment" : "")
+        );
+    }
+
+}
+

--- a/src/Urls.php
+++ b/src/Urls.php
@@ -20,7 +20,7 @@ class Urls {
         return (
             (\strlen($authority) > 0 ? "//$authority" : "") .
             ($parsed['path'] ?? "") .
-            (\strlen($query) > 0 ? "?$query" : "") .
+            (\strlen($query ?? '') > 0 ? "?$query" : "") .
             (\strlen($fragment) > 0 ? "#$fragment" : "")
         );
     }

--- a/tests/urls_test.php
+++ b/tests/urls_test.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+use \PHPUnit\Framework\TestCase;
+use Missing\Urls;
+
+class Urls_test extends \PHPUnit\Framework\TestCase {
+    public function test_unparse_url() {
+        $urls = [
+            '',
+            'foo',
+            'http://www.google.com/',
+            'http://u:p@foo:1/path/path?q#frag',
+            'http://u:p@foo:1/path/path?#',
+            'ssh://root@host',
+            '://:@:1/?#',
+            'http://:@foo:1/path/path?#',
+            'http://@foo:1/path/path?#',
+        ];
+        
+        
+        foreach ($urls as $url) {
+            $parsed = parse_url($url);
+            $rebuild = Urls::unparse_url($parsed);
+            
+    
+            $this->assertEquals($url, $rebuild, "Failed for URL: $url");
+        }
+    }   
+
+}


### PR DESCRIPTION
### Description:
This PR is in relation to Issue #19 and implements `unparse_url()` function to complement PHP's native `parse_url()`. While `parse_url()` parses a URL into its components, PHP does not provide a built-in way to reconstruct the URL, which is why this function is needed.

### Change:
- I created a PHPUnit test  in `urls_test.php` to check the functionality before writing the actual implementation into the `src` folder.
- I created `Urls.php` file in the `src/` folder to implement the `unparse_url()` function.

### Reference:
-  https://stackoverflow.com/questions/4354904/php-parse-url-reverse-parsed-url/31691249#31691249 provided in the issue #19

### Consideration:
- This implementation is based on the Stackoverflow solution (see link above)

### How to test:




